### PR TITLE
do not generate routeTree.gen.ts on docker build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,18 +1,33 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react-swc";
-
-import path from "path";
-import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
+import { defineConfig, type PluginOption } from 'vite'
+import react from '@vitejs/plugin-react-swc'
+import path from 'path'
+import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react(), TanStackRouterVite()],
-  define: {
-    "process.env": {},
-  },
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ command }) => {
+  const plugins: PluginOption[] = [react()]
+
+  // This will only enable the TanStack Router plugin for the 'serve' (dev)
+  // command. The 'build' command will not run the plugin, and will instead
+  // use the existing `routeTree.gen.ts` file from your repository.
+  if (command === 'serve') {
+    plugins.push(TanStackRouterVite())
+  }
+
+  return {
+    plugins,
+    define: {
+      'process.env': {},
     },
-  },
-});
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
+    },
+    server: {
+      watch: {
+        ignored: ['**/src/routeTree.gen.ts'],
+      },
+    },
+  }
+})


### PR DESCRIPTION
Docker build stucks on Line:
` File .../src/routeTree.gen.ts was modified by another process during processing`

This changes skips src/routeTree.gen.ts generation on docker build and resolves the issue.
also added routeTree.gen.ts to ignore list for watched files